### PR TITLE
Upgrade to TestNG 7

### DIFF
--- a/jmacaroons-core/pom.xml
+++ b/jmacaroons-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.14.3</version>
+            <version>7.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
PitTest now supports TestNG7, so we can get off the old TestNG 6 branch.